### PR TITLE
Don't parse storage untracked event values

### DIFF
--- a/src/usePersistedState.js
+++ b/src/usePersistedState.js
@@ -9,9 +9,11 @@ const usePersistedState = (initialState, key, { get, set }) => {
 
   // subscribe to `storage` change events
   useEventListener('storage', ({ key: k, newValue }) => {
-    const newState = JSON.parse(newValue);
-    if (k === key && state !== newState) {
-      setState(newState);
+    if (k === key) {
+      const newState = JSON.parse(newValue);
+      if (state !== newState) {
+        setState(newState);
+      }
     }
   });
 


### PR DESCRIPTION
Parsing all values that are persisted into the local storage may create unnecessary performance drop if the local storage is heavily used. By nesting the checks we make sure that we parse the value only when the key is the one we watch.