### PR TITLE
Added react@^17.0.0 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "jest": {
     "coverageThreshold": {


### PR DESCRIPTION
This PR adds react@^17.0.0 as a peer dependency in order to avoid warnings on projects that use latest versions of React.