### PR TITLE
State memoization with deep comparison

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "use-persisted-state",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3099,6 +3099,11 @@
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
+    },
+    "dequal": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
     },
     "detect-indent": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     }
   },
   "dependencies": {
-    "@use-it/event-listener": "^0.1.2"
+    "@use-it/event-listener": "^0.1.2",
+    "dequal": "^2.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0"
   },
   "jest": {
     "coverageThreshold": {

--- a/src/useMemoizedObject.js
+++ b/src/useMemoizedObject.js
@@ -1,0 +1,15 @@
+import { useRef } from 'react';
+import { dequal } from 'dequal/lite';
+
+const useMemoizedObject = (obj) => {
+  const mem = useRef();
+
+  if (dequal(mem.current, obj)) {
+    return mem.current;
+  }
+
+  mem.current = obj;
+  return obj;
+};
+
+export default useMemoizedObject;

--- a/src/usePersistedState.js
+++ b/src/usePersistedState.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { dequal } from 'dequal/lite';
 import useEventListener from '@use-it/event-listener';
 
 import createGlobalState from './createGlobalState';
@@ -11,7 +12,7 @@ const usePersistedState = (initialState, key, { get, set }) => {
   useEventListener('storage', ({ key: k, newValue }) => {
     if (k === key) {
       const newState = JSON.parse(newValue);
-      if (state !== newState) {
+      if (!dequal(state, newState)) {
         setState(newState);
       }
     }

--- a/src/usePersistedState.js
+++ b/src/usePersistedState.js
@@ -3,10 +3,12 @@ import { dequal } from 'dequal/lite';
 import useEventListener from '@use-it/event-listener';
 
 import createGlobalState from './createGlobalState';
+import useMemoizedObject from './useMemoizedObject';
 
 const usePersistedState = (initialState, key, { get, set }) => {
   const globalState = useRef(null);
-  const [state, setState] = useState(() => get(key, initialState));
+  const [_state, setState] = useState(() => get(key, initialState));
+  const state = useMemoizedObject(_state);
 
   // subscribe to `storage` change events
   useEventListener('storage', ({ key: k, newValue }) => {
@@ -29,16 +31,13 @@ const usePersistedState = (initialState, key, { get, set }) => {
   }, []);
 
   // Only persist to storage if state changes.
-  useEffect(
-    () => {
-      // persist to localStorage
-      set(key, state);
+  useEffect(() => {
+    // persist to localStorage
+    set(key, state);
 
-      // inform all of the other instances in this tab
-      globalState.current.emit(state);
-    },
-    [state]
-  );
+    // inform all of the other instances in this tab
+    globalState.current.emit(state);
+  }, [state]);
 
   return [state, setState];
 };


### PR DESCRIPTION
This PR closes #33. It uses [dequal](https://github.com/lukeed/dequal) to perform deep value comparison between the old and the new state in order to avoid unnecessary renders on client components.