### PR TITLE
export usePersistedState

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,4 +29,4 @@ const createPersistedState = (key, provider = getProvider()) => {
   return useState;
 };
 
-export default createPersistedState;
+export { usePersistedState, createPersistedState as default };


### PR DESCRIPTION
I'd like to use an alternate `createStorage` that prevents errors from being thrown when attempting to access the storage provider. There can be many reasons why an error might be thrown, such as #31 or when for whatever reason the local storage value is corrupted (through user error / bugs), or when local storage is disabled.

The best way I think this can be done is through exporting `usePersistedState` and letting the user create their own factory wrapper, as for example in our implementation we catch the error and report it to our sentry instance.