### PR TITLE
feat(createStorage): add reviver option to the JSON.parse call

### DIFF
--- a/__tests__/createStorage.test.js
+++ b/__tests__/createStorage.test.js
@@ -69,4 +69,33 @@ describe('createStorage', () => {
       expect(get('key')).toBe(undefined);
     });
   });
+
+  describe('parseReviver', () => {
+    test('format specific values by key', () => {
+      const mockProvider = new Provider();
+      const { get, set } = createStorage(mockProvider, {
+        parseReviver: (key, value) => (key === 'Alice' ? value * 2 : value),
+      });
+
+      set('people', {
+        Ben: 41,
+        Alice: 24,
+      });
+      expect(get('people')).toEqual({
+        Ben: 41,
+        Alice: 48,
+      });
+    });
+
+    test('format to Date from string', () => {
+      const mockProvider = new Provider();
+      const { get, set } = createStorage(mockProvider, {
+        parseReviver: (_key, value) => new Date(value),
+      });
+
+      set('today', new Date(2019, 12, 31));
+      expect(get('today')).toBeInstanceOf(Date);
+      expect(get('today')).toEqual(new Date(2019, 12, 31));
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "use-persisted-state",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/createStorage.js
+++ b/src/createStorage.js
@@ -1,4 +1,4 @@
-const createStorage = (provider) => ({
+const createStorage = (provider, { parseReviver } = {}) => ({
   get(key, defaultValue) {
     const json = provider.getItem(key);
     // eslint-disable-next-line no-nested-ternary
@@ -6,7 +6,7 @@ const createStorage = (provider) => ({
       ? typeof defaultValue === 'function'
         ? defaultValue()
         : defaultValue
-      : JSON.parse(json);
+      : JSON.parse(json, parseReviver);
   },
   set(key, value) {
     provider.setItem(key, JSON.stringify(value));

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,13 @@ const getProvider = () => {
   return null;
 };
 
-const createPersistedState = (key, provider = getProvider()) => {
+const createPersistedState = (
+  key,
+  provider = getProvider(),
+  { parseReviver } = {}
+) => {
   if (provider) {
-    const storage = createStorage(provider);
+    const storage = createStorage(provider, { parseReviver });
     return (initialState) => usePersistedState(initialState, key, storage);
   }
   return useState;


### PR DESCRIPTION
## Description

Dear community,

I discovered that one of the must-have capabilities of this hook is missing, which makes it pretty inconvenient to use in some cases. Upon creating the storage it automatically takes care of serializing & deserializing data, yet [reviver parameter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#parameters) of `JSON.parse` is unfortunately missed, which makes it difficult to specify custom rules for deserialization. 

Please link an existing issue concerning this case if there is one.

## Example

```js
localStorage.setItem('example_date', JSON.stringify(new Date()))

// How hook works right now
localStorage.getItem('example_date') // => ""2021-03-29T17:50:17.010Z""
typeof localStorage.getItem('example_date') // => string
JSON.parse(localStorage.getItem('example_date')).getMonth()) // => Uncaught TypeError: JSON.parse(...).getMonth is not a function

// Functionality introduced in this PR
typeof JSON.parse(localStorage.getItem('example_date'), (_key, value) => new Date(value)) // => "object"
JSON.parse(localStorage.getItem('example_date'), (_key, value) => new Date(value)).getMonth()) // => 2
```